### PR TITLE
Potential solution for templates in /swarms/issues/632

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,29 @@
 GROQ_API_KEY="your_groq_key"
 WORKSPACE_DIR="agent_workspace"
+
+# Other options for environmental variables
+# OPENAI_API_KEY="sk-"
+# GOOGLE_API_KEY=""
+# ANTHROPIC_API_KEY=""
+# AI21_API_KEY="your_api_key_here"
+# COHERE_API_KEY="your_api_key_here"
+# ALEPHALPHA_API_KEY="your_api_key_here"
+# HUGGINFACEHUB_API_KEY="your_api_key_here"
+# EVAL_PORT=8000
+# MODEL_NAME="gpt-4"
+
+# USE_GPU=True
+# PLAYGROUND_DIR="examples"
+
+# LOG_LEVEL="INFO"
+# BOT_NAME="Orca"
+# HF_API_KEY="your_huggingface_api_key_here"
+# AGENTOPS_API_KEY=""
+# FIREWORKS_API_KEY=""
+# OPENAI_API_KEY=your_openai_api_key
+# ANTHROPIC_API_KEY=your_anthropic_api_key
+# AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint
+# AZURE_OPENAI_DEPLOYMENT=your_azure_openai_deployment
+# OPENAI_API_VERSION=your_openai_api_version
+# AZURE_OPENAI_API_KEY=your_azure_openai_api_key
+# AZURE_OPENAI_AD_TOKEN=your_azure_openai_ad_token

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import os
-
 from dotenv import load_dotenv
+# Load workspace directory from environment variable or set path here
+WORKSPACE_DIR = os.getenv("WORKSPACE_DIR")
+os.environ["WORKSPACE_DIR"] = WORKSPACE_DIR
 from loguru import logger
 from swarm_models import OpenAIChat
 


### PR DESCRIPTION
### Summary:
This PR implements an "in situ" workaround for setting the `WORKSPACE_DIR` environment variable before loading environment variables, preventing errors in Google Colab. Additionally, the `.env.example` file has been updated to include commented-out examples of other environment variables for demonstration purposes.

Issue: https://github.com/kyegomez/swarms/issues/632
Maintainers: @kyegomez, @evelynmitchell 

---

### Changes:

#### 1. **Workspace Directory Setup:**
Declared and set `WORKSPACE_DIR` before loading environment variables to prevent errors in Colab.
```python
import os
from dotenv import load_dotenv

# Set workspace directory
WORKSPACE_DIR = os.getenv("WORKSPACE_DIR")
os.environ["WORKSPACE_DIR"] = WORKSPACE_DIR
load_dotenv()
